### PR TITLE
Added definition of lua_number2int for Lua 5.1

### DIFF
--- a/numlua.h
+++ b/numlua.h
@@ -25,6 +25,7 @@
 #define NUMLUA_API extern
 
 #if LUA_VERSION_NUM <= 501
+#define lua_number2int(i,n) ((i)=(int)(n))
 #define lua_rawlen lua_objlen
 #define nl_register(L,l,n) luaL_openlib(L,NULL,l,n)
 #define luaL_newlibtable(L,l) \


### PR DESCRIPTION
I was unable to to load numlua library, kept getting error message:
    /usr/local/lib/lua/5.1/numlua.so: undefined symbol: lua_number2int
Adding this definition alleviated the problem.
